### PR TITLE
FIX: Add a logger instance to use prior to starting ultravisor.

### DIFF
--- a/lib/service_skeleton/config.rb
+++ b/lib/service_skeleton/config.rb
@@ -8,7 +8,7 @@ require "loggerstash"
 
 module ServiceSkeleton
   class Config
-    attr_reader :logger, :env, :service_name
+    attr_reader :logger, :pre_logger, :env, :service_name
 
     def initialize(env, service_name, variables)
       @service_name = service_name
@@ -66,6 +66,11 @@ module ServiceSkeleton
 
       @logger = Logger.new(log_file || $stderr, shift_age, shift_size)
 
+      # Can be used prior to a call to ultravisor#run. This prevents a race condition
+      # when a logstash server is configured but the logstash writer is not yet
+      # initialised.
+      @pre_logger = Logger.new(log_file || $stderr, shift_age, shift_size)
+
       if Thread.main
         Thread.main[:thread_map_number] = 0
       else
@@ -76,21 +81,23 @@ module ServiceSkeleton
 
       thread_map_mutex = Mutex.new
 
-      @logger.formatter = ->(s, t, p, m) do
-        th_n = if Thread.current.name
-          #:nocov:
-          Thread.current.name
-          #:nocov:
-        else
-          thread_map_mutex.synchronize do
-            Thread.current[:thread_map_number] ||= begin
-              Thread.list.select { |th| th[:thread_map_number] }.length
+      [@logger, @pre_logger].each do |logger|
+        logger.formatter = ->(s, t, p, m) do
+          th_n = if Thread.current.name
+            #:nocov:
+            Thread.current.name
+            #:nocov:
+          else
+            thread_map_mutex.synchronize do
+              Thread.current[:thread_map_number] ||= begin
+                Thread.list.select { |th| th[:thread_map_number] }.length
+              end
             end
           end
-        end
 
-        ts = log_enable_timestamps ? "#{t.utc.strftime("%FT%T.%NZ")} " : ""
-        "#{ts}#{$$}##{th_n} #{s[0]} [#{p}] #{m}\n"
+          ts = log_enable_timestamps ? "#{t.utc.strftime("%FT%T.%NZ")} " : ""
+          "#{ts}#{$$}##{th_n} #{s[0]} [#{p}] #{m}\n"
+        end
       end
 
       @logger.filters = []

--- a/lib/service_skeleton/config.rb
+++ b/lib/service_skeleton/config.rb
@@ -8,7 +8,7 @@ require "loggerstash"
 
 module ServiceSkeleton
   class Config
-    attr_reader :logger, :pre_logger, :env, :service_name
+    attr_reader :logger, :pre_run_logger, :env, :service_name
 
     def initialize(env, service_name, variables)
       @service_name = service_name
@@ -68,8 +68,8 @@ module ServiceSkeleton
 
       # Can be used prior to a call to ultravisor#run. This prevents a race condition
       # when a logstash server is configured but the logstash writer is not yet
-      # initialised.
-      @pre_logger = Logger.new(log_file || $stderr, shift_age, shift_size)
+      # initialised. This should never be updated after it is configured.
+      @pre_run_logger = Logger.new(log_file || $stderr, shift_age, shift_size)
 
       if Thread.main
         Thread.main[:thread_map_number] = 0
@@ -81,7 +81,7 @@ module ServiceSkeleton
 
       thread_map_mutex = Mutex.new
 
-      [@logger, @pre_logger].each do |logger|
+      [@logger, @pre_run_logger].each do |logger|
         logger.formatter = ->(s, t, p, m) do
           th_n = if Thread.current.name
             #:nocov:

--- a/lib/service_skeleton/generator.rb
+++ b/lib/service_skeleton/generator.rb
@@ -45,7 +45,7 @@ module ServiceSkeleton
       end
 
       if config.metrics_port
-        config.logger.info(config.service_name) { "Starting metrics server on port #{config.metrics_port}" }
+        config.pre_run_logger.info(config.service_name) { "Starting metrics server on port #{config.metrics_port}" }
         ultravisor.add_child(
           id: :metrics_server,
           klass: Frankenstein::Server,
@@ -62,7 +62,7 @@ module ServiceSkeleton
 
     def initialize_loggerstash(ultravisor, config, registry)
       if config.logstash_server && !config.logstash_server.empty?
-        config.logger.info(config.service_name) { "Configuring loggerstash to send to #{config.logstash_server}" }
+        config.pre_run_logger.info(config.service_name) { "Configuring loggerstash to send to #{config.logstash_server}" }
 
         ultravisor.add_child(
           id: :logstash_writer,

--- a/lib/service_skeleton/runner.rb
+++ b/lib/service_skeleton/runner.rb
@@ -33,8 +33,8 @@ module ServiceSkeleton
     end
 
     def run
-      logger.info(logloc) { "Starting service #{@config.service_name}" }
-      logger.info(logloc) { (["Environment:"] + @config.env.map { |k, v| "#{k}=#{v.inspect}" }).join("\n  ") }
+      @config.pre_logger.info(logloc) { "Starting service #{@config.service_name}" }
+      @config.pre_logger.info(logloc) { (["Environment:"] + @config.env.map { |k, v| "#{k}=#{v.inspect}" }).join("\n  ") }
 
       @ultravisor.run
     end

--- a/lib/service_skeleton/runner.rb
+++ b/lib/service_skeleton/runner.rb
@@ -33,8 +33,8 @@ module ServiceSkeleton
     end
 
     def run
-      @config.pre_logger.info(logloc) { "Starting service #{@config.service_name}" }
-      @config.pre_logger.info(logloc) { (["Environment:"] + @config.env.map { |k, v| "#{k}=#{v.inspect}" }).join("\n  ") }
+      @config.pre_run_logger.info(logloc) { "Starting service #{@config.service_name}" }
+      @config.pre_run_logger.info(logloc) { (["Environment:"] + @config.env.map { |k, v| "#{k}=#{v.inspect}" }).join("\n  ") }
 
       @ultravisor.run
     end

--- a/spec/service_skeleton/config/all_spec.rb
+++ b/spec/service_skeleton/config/all_spec.rb
@@ -19,8 +19,7 @@ describe ServiceSkeleton::Config do
     end
 
     it "logs to stderr" do
-      expect(Logger).to receive(:new).with($stderr, 3, 1048576).and_call_original
-
+      expect(Logger).to receive(:new).twice.with($stderr, 3, 1048576).and_call_original
       config
     end
 
@@ -87,7 +86,7 @@ describe ServiceSkeleton::Config do
       let(:env) { { "SPEC_SERVICE_LOG_FILE" => "/var/log/spec_service.log" } }
 
       it "configures the logger appropriately" do
-        expect(Logger::LogDevice).to receive(:new).with("/var/log/spec_service.log", include(shift_age: 3, shift_size: 1048576))
+        expect(Logger::LogDevice).to receive(:new).twice.with("/var/log/spec_service.log", include(shift_age: 3, shift_size: 1048576))
 
         config
       end
@@ -97,7 +96,7 @@ describe ServiceSkeleton::Config do
       let(:env) { { "SPEC_SERVICE_LOG_MAX_FILE_SIZE" => "1234567" } }
 
       it "configures the logger appropriately" do
-        expect(Logger::LogDevice).to receive(:new).with($stderr, include(shift_age: 3, shift_size: 1234567))
+        expect(Logger::LogDevice).to receive(:new).twice.with($stderr, include(shift_age: 3, shift_size: 1234567))
 
         config
       end
@@ -107,7 +106,7 @@ describe ServiceSkeleton::Config do
       let(:env) { { "SPEC_SERVICE_LOG_MAX_FILE_SIZE" => "0" } }
 
       it "configures the logger appropriately" do
-        expect(Logger::LogDevice).to receive(:new).with($stderr, include(shift_age: 0, shift_size: 0))
+        expect(Logger::LogDevice).to receive(:new).twice.with($stderr, include(shift_age: 0, shift_size: 0))
 
         config
       end
@@ -117,7 +116,7 @@ describe ServiceSkeleton::Config do
       let(:env) { { "SPEC_SERVICE_LOG_MAX_FILES" => "42" } }
 
       it "configures the logger appropriately" do
-        expect(Logger::LogDevice).to receive(:new).with($stderr, include(shift_age: 42, shift_size: 1048576))
+        expect(Logger::LogDevice).to receive(:new).twice.with($stderr, include(shift_age: 42, shift_size: 1048576))
 
         config
       end


### PR DESCRIPTION
When configuring a service to use Logstash, we configure a LogstashWriter
instance to run via ultravisor. The @config.logger is then updated to
use the LogstashWriter. The problem with that, is if we then attempt to
use the @config.logger prior to calling `ultravisor#run` we get a thread
deadlock exception because the writer is not yet initialised.

In order to fix this race condition, create a @config.pre_logger
that is configured the same way as the standard logger, but is never
augmented after creation to use logstash writer (or other filters). That
way logs can be printed safely using pre_logger prior to the calls to
`ultravisor#run`.

The specific error message fixed is:

```
/usr/local/bundle/gems/ultravisor-0.0.0.3.g8cf10dc/lib/ultravisor/child.rb:400:in
`sleep': No live threads left. Deadlock? (fatal)
1 threads, 1 sleeps current:0x000055ed5fa79540 main
  thread:0x000055ed5fa79540
* #<Thread:0x000055ed5faacb78 sleep_forever>
```
because a child instance is attempted to be accessed before it is
started.