### PR TITLE
Add release action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
 
 jobs:
   build:
@@ -34,3 +36,13 @@ jobs:
         run: bundle exec rubocop
       - name: Tests
         run: bundle exec rspec
+  publish:
+    if: contains(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Release GEm
+        uses: CvX/publish-rubygems-action@master
+        env:
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Release GEm
+      - name: Release Gem
         uses: CvX/publish-rubygems-action@master
         env:
           RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}

--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,3 @@ class Bundler::GemHelper
 end
 
 Bundler::GemHelper.install_tasks
-task :release do
-  sh "git release"
-end


### PR DESCRIPTION
Add an action to push a release to rubygems once a tag (starting with
'v') is pushed to the repo.

Also remove the 'release' rake task. This is causing an error to occur
for automated publishing. Prefer the default release task from
Bundler::GemHelper.install_tasks.