### PR TITLE
ultravisor: for exception during castcall method, notify caller

### DIFF
--- a/ultravisor/lib/ultravisor/child/call.rb
+++ b/ultravisor/lib/ultravisor/child/call.rb
@@ -8,6 +8,10 @@ class Ultravisor::Child::Call
 
   def go!(receiver)
     @rv_q << receiver.__send__(@method_name, *@args, &@blk)
+  rescue Exception => ex
+    @rv_q << @rv_fail
+    raise
+  ensure
     @rv_q.close
   end
 

--- a/ultravisor/spec/ultravisor/child/call_spec.rb
+++ b/ultravisor/spec/ultravisor/child/call_spec.rb
@@ -6,11 +6,17 @@ require_relative "../../../lib/ultravisor/child"
 require_relative "../../../lib/ultravisor/error"
 
 class CastCallTest
+  class FakeError < RuntimeError; end
+
   def run
   end
 
   def poke_processor
     process_castcall
+  end
+
+  def failing_method
+    raise FakeError
   end
 end
 
@@ -49,6 +55,7 @@ describe Ultravisor::Child do
 
         # So we can check if and when it's been called
         allow(instance).to receive(:to_s).and_call_original
+        allow(instance).to receive(:failing_method).and_call_original
       end
 
       it "accepts calls to #call" do
@@ -80,6 +87,17 @@ describe Ultravisor::Child do
         instance.poke_processor
         expect(instance).to have_received(:to_s)
         expect(th.value).to be_a(String)
+      end
+
+      it "raises a relevant error if the call itself causes an exception is dying" do
+        th = Thread.new { child.call.failing_method }
+        th.join(0.001)
+
+        expect(instance).to_not have_received(:failing_method)
+        expect { instance.poke_processor }.to raise_error(CastCallTest::FakeError)
+        expect(instance).to have_received(:failing_method)
+
+        expect { th.value }.to raise_error(Ultravisor::ChildRestartedError)
       end
 
       it "raises a relevant error if the instance is dying" do


### PR DESCRIPTION
Previously the caller would never receive any notification that the
child had failed, and would block forever. This commit treats a failure
during the call the same way as a failure while the call is queuing.

(This PR is temporarily based against #6)