### PR TITLE
FIX: Never block waiting for loggerstash worker

### DIFF
--- a/lib/service_skeleton/ultravisor_loggerstash.rb
+++ b/lib/service_skeleton/ultravisor_loggerstash.rb
@@ -4,8 +4,16 @@ module ServiceSkeleton
   module UltravisorLoggerstash
     def logstash_writer
       #:nocov:
-      @ultravisor[:logstash_writer].unsafe_instance
+      @ultravisor[:logstash_writer].unsafe_instance(wait: false)
       #:nocov:
+    end
+
+    # logstash_writer will be nil if the logstash_writer worker is not running
+    # Ultravisor's restart policy ensures this will never happen at runtime. But
+    # it does happen during startup and shutdown. In this case, we want to skip
+    # writing to logstash, not block forever. STDOUT logging will continue.
+    def loggerstash_log_message(*args)
+      super if !logstash_writer.nil?
     end
   end
 end

--- a/ultravisor/lib/ultravisor/child.rb
+++ b/ultravisor/lib/ultravisor/child.rb
@@ -185,13 +185,13 @@ class Ultravisor
       !!(@restart == :always || (@restart == :on_failure && termination_exception))
     end
 
-    def unsafe_instance
+    def unsafe_instance(wait: true)
       unless @access == :unsafe
         raise Ultravisor::ThreadSafetyError,
               "#unsafe_instance called on a child not declared with access: :unsafe"
       end
 
-      current_instance
+      current_instance(wait: wait)
     end
 
     def cast
@@ -394,9 +394,9 @@ class Ultravisor
       end
     end
 
-    def current_instance
+    def current_instance(wait: true)
       @spawn_m.synchronize do
-        while @instance.nil?
+        while wait && @instance.nil?
           @spawn_cv.wait(@spawn_m)
         end
 


### PR DESCRIPTION
logstash_writer will be nil if the logstash_writer worker is not running
Ultravisor's restart policy ensures this will never happen at runtime. But
it does happen during startup and shutdown. In this case, we want to skip
writing to logstash, not block forever. STDOUT logging will continue.