### PR TITLE
FIX: Ruby 3 compatibility

### DIFF
--- a/spec/service_skeleton_filtering_logger_spec.rb
+++ b/spec/service_skeleton_filtering_logger_spec.rb
@@ -3,10 +3,11 @@
 require_relative "./spec_helper"
 
 require "service_skeleton/filtering_logger"
+require "tempfile"
 
 describe FilteringLogger do
-  let(:logger) { Logger.new("/dev/null") }
-  let(:logdev) { logger.instance_variable_get(:@logdev) }
+  let(:logger) { Logger.new(logdev) }
+  let(:logdev) { Tempfile.new }
 
   it "accepts a filter spec" do
     expect { logger.filters = [["buggy", Logger::DEBUG], [/noisy/i, Logger::ERROR]] }.to_not raise_error

--- a/ultravisor/lib/ultravisor/child.rb
+++ b/ultravisor/lib/ultravisor/child.rb
@@ -381,6 +381,10 @@ class Ultravisor
       # urgh.
       if @klass.instance_method(:initialize).arity == 0
         @klass.new()
+      elsif @args.is_a?(Hash)
+        @klass.new(**@args)
+      elsif @args.last.is_a?(Hash)
+        @klass.new(*@args[0...-1], **@args.last)
       else
         @klass.new(*@args)
       end.tap do |i|


### PR DESCRIPTION
Included:

* DEV: Fix ruby 3 incompatibility in specs
  Logger.new now treats `File::NULL` (`"/dev/null"`) the same as `nil`, which means it doesn't create `@logdev` at all.
* FIX: Handle keyword arguments changes in ruby 3