### PR TITLE
FIX: Handle "bad file selector" errors

### DIFF
--- a/lib/service_skeleton/signal_manager.rb
+++ b/lib/service_skeleton/signal_manager.rb
@@ -81,7 +81,7 @@ module ServiceSkeleton
               logger.error(logloc) { "Mysterious return from select: #{ios.inspect}" }
             end
           end
-        rescue IOError
+        rescue IOError, Errno::EBADF
           # Something has gone terribly wrong here... bail
           break
         rescue StandardError => ex

--- a/service_skeleton.gemspec
+++ b/service_skeleton.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.name = "service_skeleton"
 
-  s.version = '2.0.1'
+  s.version = '2.0.2'
 
   s.platform = Gem::Platform::RUBY
 


### PR DESCRIPTION
On ruby 3 (on macOS) `IO.select` seems to raise `Errno::EBADF` when the signal pipe is closing/closed. Since the pipe is closed at that point, just rescue the error and move on.