### PR TITLE
Add hurriable_timer(_sequence)

### DIFF
--- a/lib/service_skeleton.rb
+++ b/lib/service_skeleton.rb
@@ -3,6 +3,8 @@
 require_relative "service_skeleton/config_class"
 require_relative "service_skeleton/config_variables"
 require_relative "service_skeleton/generator"
+require_relative "service_skeleton/hurriable_timer"
+require_relative "service_skeleton/hurriable_timer_sequence"
 require_relative "service_skeleton/logging_helpers"
 require_relative "service_skeleton/metrics_methods"
 require_relative "service_skeleton/service_name"

--- a/lib/service_skeleton/hurriable_timer.rb
+++ b/lib/service_skeleton/hurriable_timer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# A mechanism for waiting until a timer expires or until another thread signals
+# readiness.
+class ServiceSkeleton::HurriableTimer
+  def initialize(timeout)
+    @mutex = Mutex.new
+    @condition = ConditionVariable.new
+    @end_time = now + timeout
+    @hurried = false
+  end
+
+  # Wait for the timer to elapse
+  #
+  # Any number of threads can wait on the same HurriableTimer
+  def wait(t = nil)
+    end_time =
+      if t
+        [@end_time, now + t].min
+      else
+        @end_time
+      end
+
+    @mutex.synchronize {
+      while true
+        remaining = end_time - now
+
+        if remaining < 0 || @hurried
+          break
+        else
+          @condition.wait(@mutex, remaining)
+        end
+      end
+    }
+
+    nil
+  end
+
+  # Cause the timer to trigger early if it hasn't already expired
+  #
+  # This method is idempotent
+  def hurry!
+    @mutex.synchronize {
+      @hurried = true
+      @condition.broadcast
+    }
+
+    nil
+  end
+
+  def expired?
+    @hurried || @end_time - now < 0
+  end
+
+  private
+
+  def now
+    # Using this instead of Time.now, because it isn't affected by NTP updates
+    Process.clock_gettime(Process::CLOCK_MONOTONIC_RAW)
+  end
+end

--- a/lib/service_skeleton/hurriable_timer_sequence.rb
+++ b/lib/service_skeleton/hurriable_timer_sequence.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# HurribleTimerSequence is a resettable version of HurriableTimer, designed for
+# cases where some action needs to happen at at least some frequency, but may
+# happen more often when other threads trigger the process early.
+#
+# It would have been possible to implement this without requiring allocation on
+# reset, by reusing the mutex and condition variable in the normal timer, but
+# this version is more obviously correct.
+class ServiceSkeleton::HurriableTimerSequence
+  def initialize(timeout)
+    @mutex = Mutex.new
+    @timeout = timeout
+    @latest = ServiceSkeleton::HurriableTimer.new(@timeout)
+  end
+
+  def reset!
+    @mutex.synchronize {
+      @latest.hurry!
+      @latest = ServiceSkeleton::HurriableTimer.new(@timeout)
+    }
+  end
+
+  def wait(t = nil)
+    @mutex.synchronize { @latest }.wait(t)
+  end
+
+  def hurry!
+    @mutex.synchronize { @latest }.hurry!
+  end
+
+  def expired?
+    @mutex.synchronize { @latest }.expired?
+  end
+end


### PR DESCRIPTION
Used for operations that need to happen at at least some frequency, but can be triggered early.

I started writing tests for this, but it's complicated, so I don't want to wait on tests being written to merge this.